### PR TITLE
pin installer image to something we vendor

### DIFF
--- a/snapshot-setup-daemonset.yaml
+++ b/snapshot-setup-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
         effect: NoExecute
       containers:
       - name: snapshot-setup
-        image: alpine:3.18
+        image: public.ecr.aws/devzeroinc/alpine@sha256:de0eb0b3f2a47ba1eb89389859a9bd88b28e82f5826b6969ad604979713c2d4f
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true


### PR DESCRIPTION
mirror alpine on our own registry, and pin it at a specific SHA