### PR TITLE
Scheduler updates

### DIFF
--- a/helm/dakr/templates/scheduler.yaml
+++ b/helm/dakr/templates/scheduler.yaml
@@ -45,6 +45,28 @@ subjects:
   name: dz-scheduler
   namespace: kube-system
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dz-scheduler-configmap-reader
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dz-scheduler-configmap-reader
+subjects:
+- kind: ServiceAccount
+  name: dz-scheduler
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: dz-scheduler-configmap-reader
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -59,20 +81,61 @@ data:
         pluginConfig:
         - name: TargetAllocated 
           args:
-            memoryAllocatedPercent: 80
-            cpuAllocatedPercent: 80
+            memoryAllocatedPercent: 99
+            cpuAllocatedPercent: 99
+        - name: LimitOverProvisionControl 
+          args:
+            cpuOverProvisionPenalizeRatio: 180
+            memoryOverProvisionPenalizeRatio: 180
+        - name: NodeCost
+          args:
+            controlPlaneAddress: {{ .Values.scheduler.nodeCost.controlPlaneAddress | quote }}
+            controlPlaneToken: {{ .Values.scheduler.nodeCost.controlPlaneToken | quote }}
+            tokenFromConfigMap:
+              name: {{ .Values.scheduler.nodeCost.tokenFromConfigMap.name | quote }}
+              namespace: {{ .Values.scheduler.nodeCost.tokenFromConfigMap.namespace | quote }}
+              key: {{ .Values.scheduler.nodeCost.tokenFromConfigMap.key | quote }}
+        - name: PodTopologySpread
+          args:
+            defaultingType: "List"
         plugins:
           preScore:
             enabled:
+            - name: 'TaintToleration'
+              weight: 6
+            - name: 'NodeAffinity'
+              weight: 5
+            - name: 'PodTopologySpread'
+              weight: 5
+            - name: 'InterPodAffinity'
+              weight: 5
             - name: 'TargetAllocated'
+              weight: 3
+            - name: 'LimitOverProvisionControl'
               weight: 2
+            - name: 'NodeCost'
+              weight: 4
             disabled:
             - name: 'NodeResourcesFit'
             - name: 'NodeResourcesBalancedAllocation'
           score:
             enabled:
+            - name: 'TaintToleration'
+              weight: 6
+            - name: 'NodeAffinity'
+              weight: 5
+            - name: 'PodTopologySpread'
+              weight: 5
+            - name: 'InterPodAffinity'
+              weight: 5
+            - name: 'ImageLocality'
+              weight: 1
             - name: 'TargetAllocated'
+              weight: 3
+            - name: 'LimitOverProvisionControl'
               weight: 2
+            - name: 'NodeCost'
+              weight: 4
             disabled:
             - name: 'NodeResourcesFit'
             - name: 'NodeResourcesBalancedAllocation'
@@ -100,6 +163,7 @@ spec:
         tier: control-plane
         version: second
     spec:
+      priorityClassName: system-cluster-critical
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
@@ -138,4 +202,21 @@ spec:
         - name: config-volume
           configMap:
             name: dz-scheduler-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dz-scheduler
+  namespace: kube-system
+  labels:
+    component: scheduler
+    tier: control-plane
+spec:
+  selector:
+    component: scheduler
+    tier: control-plane
+  ports:
+    - name: https-healthz
+      port: 443
+      targetPort: 10259
 {{- end }}

--- a/helm/dakr/values.yaml
+++ b/helm/dakr/values.yaml
@@ -86,7 +86,14 @@ operator:
 
 scheduler:
   image:
-    tag: "v0.0.2"
+    tag: "v0.0.3"
+  nodeCost:
+    controlPlaneAddress: "https://dakr.devzero.io"
+    controlPlaneToken: ""
+    # tokenFromConfigMap: # If clusterToken is not specified above, operator will read from below ConfigMap value
+    #   name: "devzero-zxporter-env-config" # Name of the ConfigMap
+    #   namespace: "devzero-zxporter" # Namespace of the ConfigMap
+    #   key: "CLUSTER_TOKEN" # Key in the ConfigMap's data to get the token
 
 
 


### PR DESCRIPTION
**Adds 2 plugins:**
NodeCost: Prioritizes scheduling pods on the most cost-effective nodes. It fetches real-time node pricing information and scores nodes based on the cost of placing a pod on them.
LimitOverProvisionControl: Prevents resource overcommitment by penalizing nodes where the sum of container resource limits exceeds the node's capacity.

**Tweaks the weights and configs such that:**

- NodeCost has the highest weight, we will first try to place things on cheaper nodes
- TargetAllocated now targets 99 percent provisioning (basically packed full) and has weight lower than NodeCost, this means scheduler will pack cheapest nodes first
- LimitOverProvisionControl has lower weight than both NodeCost and TargetAllocated, this means for equal priced and equal packing cases, we will tend to put pods on nodes for which the sum of limits is lower as the limit sum exceeds total allocatable space.

**Additionally:**
PodTopologySpread: The default pod spreading behavior has been disabled, by default even in absence of explicit user configs, this plugin will spread pods from composite resources like deployments, sts etc on diff nodes. This has been disabled, explicit user configs are still respected.