### PR TITLE
add cloudformation for dzKarp

### DIFF
--- a/dzKarp/cloudformation.yaml
+++ b/dzKarp/cloudformation.yaml
@@ -4,9 +4,12 @@ Parameters:
   ClusterName:
     Type: String
     Description: "EKS cluster name"
-  OIDCProviderURL:
+  AWSRegion:
     Type: String
-    Description: "The OIDC Provider URL from your EKS cluster, e.g. https://oidc.eks.us-west-2.amazonaws.com/id/..."
+    Description: "The AWS Region of the EKS cluster"
+  OIDCProviderID:
+    Type: String
+    Description: "The ID of the OIDC Provider from your EKS cluster, e.g. C66D5D54749FA6FAF79C0BA97D88327E"
   KarpenterNamespace:
     Type: String
     Default: "kube-system"
@@ -22,12 +25,12 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}"
+              Federated: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/oidc.eks.${AWSRegion}.amazonaws.com/id/${OIDCProviderID}"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:
-                !Sub "${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}:aud": "sts.amazonaws.com"
-                !Sub "${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}:sub": !Sub "system:serviceaccount:${KarpenterNamespace}:karpenter"
+                !Sub "oidc.eks.${AWSRegion}.amazonaws.com/id/${OIDCProviderID}:aud": "sts.amazonaws.com"
+                !Sub "oidc.eks.${AWSRegion}.amazonaws.com/id/${OIDCProviderID}:sub": !Sub "system:serviceaccount:${KarpenterNamespace}:karpenter"
       ManagedPolicyArns:
         - !Ref KarpenterControllerPolicy
   KarpenterNodeRole:

--- a/dzKarp/cloudformation.yaml
+++ b/dzKarp/cloudformation.yaml
@@ -4,12 +4,9 @@ Parameters:
   ClusterName:
     Type: String
     Description: "EKS cluster name"
-  AWSRegion:
+  OIDCProviderURL:
     Type: String
-    Description: "The AWS Region of the EKS cluster"
-  OIDCProviderID:
-    Type: String
-    Description: "The ID of the OIDC Provider from your EKS cluster, e.g. C66D5D54749FA6FAF79C0BA97D88327E"
+    Description: "The OIDC Provider URL from your EKS cluster, e.g. https://oidc.eks.us-west-2.amazonaws.com/id/..."
   KarpenterNamespace:
     Type: String
     Default: "kube-system"
@@ -25,12 +22,12 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/oidc.eks.${AWSRegion}.amazonaws.com/id/${OIDCProviderID}"
+              Federated: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}"
             Action: "sts:AssumeRoleWithWebIdentity"
             Condition:
               StringEquals:
-                !Sub "oidc.eks.${AWSRegion}.amazonaws.com/id/${OIDCProviderID}:aud": "sts.amazonaws.com"
-                !Sub "oidc.eks.${AWSRegion}.amazonaws.com/id/${OIDCProviderID}:sub": !Sub "system:serviceaccount:${KarpenterNamespace}:karpenter"
+                "${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}:aud": "sts.amazonaws.com"
+                "${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}:sub": !Sub "system:serviceaccount:${KarpenterNamespace}:karpenter"
       ManagedPolicyArns:
         - !Ref KarpenterControllerPolicy
   KarpenterNodeRole:

--- a/dzKarp/cloudformation.yaml
+++ b/dzKarp/cloudformation.yaml
@@ -4,9 +4,12 @@ Parameters:
   ClusterName:
     Type: String
     Description: "EKS cluster name"
-  OIDCProviderURL:
+  AWSRegion:
     Type: String
-    Description: "The OIDC Provider URL from your EKS cluster, e.g. https://oidc.eks.us-west-2.amazonaws.com/id/..."
+    Description: "The AWS Region of the EKS cluster"
+  OIDCProviderID:
+    Type: String
+    Description: "The ID of the OIDC Provider from your EKS cluster, e.g. C66D5D54749FA6FAF79C0BA97D88327E"
   KarpenterNamespace:
     Type: String
     Default: "kube-system"
@@ -17,17 +20,25 @@ Resources:
     Properties:
       RoleName: !Sub "KarpenterControllerRole-${ClusterName}"
       Path: /
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Federated: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}"
-            Action: "sts:AssumeRoleWithWebIdentity"
-            Condition:
-              StringEquals:
-                "${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}:aud": "sts.amazonaws.com"
-                "${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}:sub": !Sub "system:serviceaccount:${KarpenterNamespace}:karpenter"
+      AssumeRolePolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/oidc.eks.${AWSRegion}.amazonaws.com/id/${OIDCProviderID}"
+              },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "StringEquals": {
+                  "oidc.eks.${AWSRegion}.amazonaws.com/id/${OIDCProviderID}:aud": "sts.amazonaws.com",
+                  "oidc.eks.${AWSRegion}.amazonaws.com/id/${OIDCProviderID}:sub": "system:serviceaccount:${KarpenterNamespace}:karpenter"
+                }
+              }
+            }
+          ]
+        }
       ManagedPolicyArns:
         - !Ref KarpenterControllerPolicy
   KarpenterNodeRole:

--- a/dzKarp/cloudformation.yaml
+++ b/dzKarp/cloudformation.yaml
@@ -1,0 +1,399 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Resources used by https://github.com/aws/karpenter
+Parameters:
+  ClusterName:
+    Type: String
+    Description: "EKS cluster name"
+  OIDCProviderURL:
+    Type: String
+    Description: "The OIDC Provider URL from your EKS cluster, e.g. https://oidc.eks.us-west-2.amazonaws.com/id/..."
+  KarpenterNamespace:
+    Type: String
+    Default: "kube-system"
+    Description: "The Kubernetes namespace where Karpenter is installed."
+Resources:
+  KarpenterControllerRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Sub "KarpenterControllerRole-${ClusterName}"
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}"
+            Action: "sts:AssumeRoleWithWebIdentity"
+            Condition:
+              StringEquals:
+                !Sub "${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}:aud": "sts.amazonaws.com"
+                !Sub "${!Select [1, !Split ['https://', !Ref OIDCProviderURL]]}:sub": !Sub "system:serviceaccount:${KarpenterNamespace}:karpenter"
+      ManagedPolicyArns:
+        - !Ref KarpenterControllerPolicy
+  KarpenterNodeRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Sub "KarpenterNodeRole-${ClusterName}"
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                !Sub "ec2.${AWS::URLSuffix}"
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  KarpenterControllerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
+      # The PolicyDocument must be in JSON string format because we use a StringEquals condition that uses an interpolated
+      # value in one of its key parameters which isn't natively supported by CloudFormation
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowScopedEC2InstanceAccessActions",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:${AWS::Partition}:ec2:${AWS::Region}::image/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}::snapshot/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:security-group/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:subnet/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
+              ],
+              "Action": [
+                "ec2:RunInstances",
+                "ec2:CreateFleet"
+              ]
+            },
+            {
+              "Sid": "AllowScopedEC2LaunchTemplateAccessActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+              "Action": [
+                "ec2:RunInstances",
+                "ec2:CreateFleet"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                },
+                "StringLike": {
+                  "aws:ResourceTag/karpenter.sh/nodepool": "*"
+                }
+              }
+            },
+            {
+              "Sid": "AllowScopedEC2InstanceActionsWithTags",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:capacity-reservation/*"
+              ],
+              "Action": [
+                "ec2:RunInstances",
+                "ec2:CreateFleet",
+                "ec2:CreateLaunchTemplate"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
+                },
+                "StringLike": {
+                  "aws:RequestTag/karpenter.sh/nodepool": "*"
+                }
+              }
+            },
+            {
+              "Sid": "AllowScopedResourceCreationTagging",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:fleet/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:volume/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:network-interface/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:spot-instances-request/*"
+              ],
+              "Action": "ec2:CreateTags",
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
+                  "ec2:CreateAction": [
+                    "RunInstances",
+                    "CreateFleet",
+                    "CreateLaunchTemplate"
+                  ]
+                },
+                "StringLike": {
+                  "aws:RequestTag/karpenter.sh/nodepool": "*"
+                }
+              }
+            },
+            {
+              "Sid": "AllowScopedResourceTagging",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+              "Action": "ec2:CreateTags",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                },
+                "StringLike": {
+                  "aws:ResourceTag/karpenter.sh/nodepool": "*"
+                },
+                "StringEqualsIfExists": {
+                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}"
+                },
+                "ForAllValues:StringEquals": {
+                  "aws:TagKeys": [
+                    "eks:eks-cluster-name",
+                    "karpenter.sh/nodeclaim",
+                    "Name"
+                  ]
+                }
+              }
+            },
+            {
+              "Sid": "AllowScopedDeletion",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:instance/*",
+                "arn:${AWS::Partition}:ec2:${AWS::Region}:*:launch-template/*"
+              ],
+              "Action": [
+                "ec2:TerminateInstances",
+                "ec2:DeleteLaunchTemplate"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned"
+                },
+                "StringLike": {
+                  "aws:ResourceTag/karpenter.sh/nodepool": "*"
+                }
+              }
+            },
+            {
+              "Sid": "AllowRegionalReadActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": [
+                "ec2:DescribeCapacityReservations",
+                "ec2:DescribeImages",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceTypeOfferings",
+                "ec2:DescribeInstanceTypes",
+                "ec2:DescribeLaunchTemplates",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSpotPriceHistory",
+                "ec2:DescribeSubnets"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestedRegion": "${AWS::Region}"
+                }
+              }
+            },
+            {
+              "Sid": "AllowSSMReadActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:ssm:${AWS::Region}::parameter/aws/service/*",
+              "Action": "ssm:GetParameter"
+            },
+            {
+              "Sid": "AllowPricingReadActions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": "pricing:GetProducts"
+            },
+            {
+              "Sid": "AllowInterruptionQueueActions",
+              "Effect": "Allow",
+              "Resource": "${KarpenterInterruptionQueue.Arn}",
+              "Action": [
+                "sqs:DeleteMessage",
+                "sqs:GetQueueUrl",
+                "sqs:ReceiveMessage"
+              ]
+            },
+            {
+              "Sid": "AllowPassingInstanceRole",
+              "Effect": "Allow",
+              "Resource": "${KarpenterNodeRole.Arn}",
+              "Action": "iam:PassRole",
+              "Condition": {
+                "StringEquals": {
+                  "iam:PassedToService": [
+                    "ec2.amazonaws.com",
+                    "ec2.amazonaws.com.cn"
+                  ]
+                }
+              }
+            },
+            {
+              "Sid": "AllowScopedInstanceProfileCreationActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
+              "Action": [
+                "iam:CreateInstanceProfile"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
+                  "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+                },
+                "StringLike": {
+                  "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
+                }
+              }
+            },
+            {
+              "Sid": "AllowScopedInstanceProfileTagActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
+              "Action": [
+                "iam:TagInstanceProfile"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}",
+                  "aws:RequestTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:RequestTag/eks:eks-cluster-name": "${ClusterName}",
+                  "aws:RequestTag/topology.kubernetes.io/region": "${AWS::Region}"
+                },
+                "StringLike": {
+                  "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*",
+                  "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass": "*"
+                }
+              }
+            },
+            {
+              "Sid": "AllowScopedInstanceProfileActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
+              "Action": [
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:DeleteInstanceProfile"
+              ],
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/kubernetes.io/cluster/${ClusterName}": "owned",
+                  "aws:ResourceTag/topology.kubernetes.io/region": "${AWS::Region}"
+                },
+                "StringLike": {
+                  "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass": "*"
+                }
+              }
+            },
+            {
+              "Sid": "AllowInstanceProfileReadActions",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*",
+              "Action": "iam:GetInstanceProfile"
+            },
+            {
+              "Sid": "AllowUnscopedInstanceProfileListAction",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Action": "iam:ListInstanceProfiles"
+            },
+            {
+              "Sid": "AllowAPIServerEndpointDiscovery",
+              "Effect": "Allow",
+              "Resource": "arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${ClusterName}",
+              "Action": "eks:DescribeCluster"
+            }
+          ]
+        }
+  KarpenterInterruptionQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${ClusterName}"
+      MessageRetentionPeriod: 300
+      SqsManagedSseEnabled: true
+  KarpenterInterruptionQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref KarpenterInterruptionQueue
+      PolicyDocument:
+        Id: EC2InterruptionPolicy
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+                - sqs.amazonaws.com
+            Action: sqs:SendMessage
+            Resource: !GetAtt KarpenterInterruptionQueue.Arn
+          - Sid: DenyHTTP
+            Effect: Deny
+            Action: sqs:*
+            Resource: !GetAtt KarpenterInterruptionQueue.Arn
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+            Principal: "*"
+  ScheduledChangeRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      EventPattern:
+        source:
+          - aws.health
+        detail-type:
+          - AWS Health Event
+      Targets:
+        - Id: KarpenterInterruptionQueueTarget
+          Arn: !GetAtt KarpenterInterruptionQueue.Arn
+  SpotInterruptionRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      EventPattern:
+        source:
+          - aws.ec2
+        detail-type:
+          - EC2 Spot Instance Interruption Warning
+      Targets:
+        - Id: KarpenterInterruptionQueueTarget
+          Arn: !GetAtt KarpenterInterruptionQueue.Arn
+  RebalanceRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      EventPattern:
+        source:
+          - aws.ec2
+        detail-type:
+          - EC2 Instance Rebalance Recommendation
+      Targets:
+        - Id: KarpenterInterruptionQueueTarget
+          Arn: !GetAtt KarpenterInterruptionQueue.Arn
+  InstanceStateChangeRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      EventPattern:
+        source:
+          - aws.ec2
+        detail-type:
+          - EC2 Instance State-change Notification
+      Targets:
+        - Id: KarpenterInterruptionQueueTarget
+          Arn: !GetAtt KarpenterInterruptionQueue.Arn


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CloudFormation template to provision Karpenter infrastructure: controller and node IAM roles/policies, an encrypted SQS interruption queue with secure-transport enforcement, and EventBridge rules for health, spot interruptions, rebalances, and instance state changes.
  * Template accepts region, cluster name, OIDC provider, and namespace parameters for easier setup.
  * Centralizes event routing to improve automation and resilience of node lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->