### PR TITLE
feat: migrate scheduler and DNS references to devzero-system namespace

### DIFF
--- a/helm/dakr/templates/scheduler.yaml
+++ b/helm/dakr/templates/scheduler.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dz-scheduler
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -242,7 +242,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: dz-scheduler
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: dz-scheduler-kube-scheduler
@@ -289,7 +289,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: dz-scheduler
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: dz-scheduler-volume-scheduler
@@ -307,7 +307,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: dz-scheduler
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -325,7 +325,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: dz-scheduler
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: dz-scheduler-configmap-reader
@@ -335,7 +335,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dz-scheduler-config
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 data:
   dz-scheduler-config.yaml: |
     apiVersion: kubescheduler.config.k8s.io/v1
@@ -423,7 +423,7 @@ metadata:
     component: scheduler
     tier: control-plane
   name: dz-scheduler
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
@@ -498,7 +498,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dz-scheduler
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
   labels:
     component: scheduler
     tier: control-plane

--- a/helm/dakr/values.yaml
+++ b/helm/dakr/values.yaml
@@ -44,7 +44,7 @@ operator:
       cpu: 10m
       memory: 64Mi
   endpoint: "https://dakr.devzero.io"
-  zxporterAddr: "devzero-zxporter-controller-manager-mpa.devzero-zxporter.svc.cluster.local:50051"
+  zxporterAddr: "devzero-zxporter-controller-manager-mpa.devzero-system.svc.cluster.local:50051"
   # Log level for the operator. Available levels:
   # - debug: Most verbose, includes debug messages
   # - info: Informational messages
@@ -65,11 +65,11 @@ operator:
   #   # the Secret must be recreated in the operator's namespace. Alternatively, install both in the same namespace.
   # tokenFromConfigMap: # If clusterToken is not specified above and not found in Secret, operator will read from below ConfigMap value
   #   name: "devzero-zxporter-env-config" # Name of the ConfigMap
-  #   namespace: "devzero-zxporter" # Namespace of the ConfigMap
+  #   namespace: "devzero-system" # Namespace of the ConfigMap
   #   key: "CLUSTER_TOKEN" # Key in the ConfigMap's data to get the token
   # nameFromConfigMap: # If clusterName is not specified above and not found in Secret, operator will read from below ConfigMap value
   #   name: "devzero-zxporter-env-config" # Name of the ConfigMap
-  #   namespace: "devzero-zxporter"       # Namespace of the ConfigMap
+  #   namespace: "devzero-system"       # Namespace of the ConfigMap
   #   key: "KUBE_CONTEXT_NAME"            # Key in the ConfigMap's data to get the cluster name from
   customScheduler: false
   port: 9443
@@ -168,7 +168,7 @@ scheduler:
     #   # If zxporter creates Secret in devzero-zxporter namespace, the Secret must be recreated in kube-system namespace.
     # tokenFromConfigMap: # If controlPlaneToken is not specified above and not found in Secret, scheduler will read from below ConfigMap value
     #   name: "devzero-zxporter-env-config" # Name of the ConfigMap
-    #   namespace: "devzero-zxporter"       # Namespace of the ConfigMap
+    #   namespace: "devzero-system"         # Namespace of the ConfigMap
     #   key: "CLUSTER_TOKEN"                # Key in the ConfigMap's data to get the token
 
   # Pod scheduling configuration


### PR DESCRIPTION
## Summary

Updates the dakr-operator Helm chart to use `devzero-system` as the default namespace, making the custom scheduler and DNS service address consistent with the rest of the DevZero operator stack.

### Changes

- **`helm/dakr/templates/scheduler.yaml`**: Replaced 8 hardcoded `kube-system` namespace references with `{{ .Release.Namespace }}` so the custom scheduler (when enabled via `operator.customScheduler: true`) deploys into whatever namespace the chart is installed into
  - ServiceAccount, 3× ClusterRoleBinding subjects, 1× RoleBinding subject, ConfigMap, Deployment, Service all use `{{ .Release.Namespace }}`
  - **Exception**: The `dz-scheduler-extension-apiserver-authentication-reader` RoleBinding metadata namespace stays as `kube-system` — this RoleBinding must live in `kube-system` because it binds to the `extension-apiserver-authentication-reader` Role which is a built-in Role that lives there
- **`helm/dakr/values.yaml`**: Updated `zxporterAddr` DNS reference from `devzero-zxporter` to `devzero-system`; updated namespace comment examples

## Testing plan

- [ ] Install chart with `--namespace devzero-system`: scheduler Deployment, Service, ConfigMap, and ServiceAccount should all be in `devzero-system`
- [ ] ClusterRoleBinding subjects should reference `devzero-system` SA
- [ ] The `dz-scheduler-extension-apiserver-authentication-reader` RoleBinding should still be in `kube-system` (verify with `kubectl get rolebinding -n kube-system`)
- [ ] Scheduler pod starts successfully and can communicate with the kube-apiserver (`kubectl logs -n devzero-system deployment/dz-scheduler`)
- [ ] Install chart with a custom namespace (e.g. `--namespace custom-ns`) — all resources except the kube-system RoleBinding should land in `custom-ns`